### PR TITLE
[CHORE] 앱 재시작 시 로그인 상태 유지

### DIFF
--- a/src/screens/splash/SplashScreen.tsx
+++ b/src/screens/splash/SplashScreen.tsx
@@ -19,6 +19,8 @@ const SplashScreen = () => {
   useEffect(() => {
     if (!fontsLoaded) return;
 
+    let isMounted = true;
+
     // 폰트 로드 완료 후 토큰 확인하여 화면 이동
     const checkAuthAndNavigate = async () => {
       try {
@@ -26,6 +28,9 @@ const SplashScreen = () => {
 
         // 2초 대기 (스플래시 화면 표시)
         await new Promise((resolve) => setTimeout(resolve, 2000));
+
+        // unmount된 경우 navigation 실행하지 않음
+        if (!isMounted) return;
 
         if (accessToken) {
           // 토큰이 있으면 메인 화면으로
@@ -42,6 +47,9 @@ const SplashScreen = () => {
         }
       } catch (error) {
         console.error("토큰 확인 중 오류:", error);
+        // unmount된 경우 navigation 실행하지 않음
+        if (!isMounted) return;
+
         // 오류 발생 시 로그인 화면으로
         navigation.reset({
           index: 0,
@@ -51,6 +59,10 @@ const SplashScreen = () => {
     };
 
     checkAuthAndNavigate();
+
+    return () => {
+      isMounted = false;
+    };
   }, [fontsLoaded, navigation]);
 
   return (


### PR DESCRIPTION
## 📄 작업 내용 요약
- SplashScreen에서 accessToken 확인 로직 추가
- 토큰 존재 시 Tabs 화면으로 자동 이동
- 토큰 없을 시 Login 화면으로 이동
- reload app 시에도 로그인 상태 유지

## 📎 Issue #66 

<!-- closed #66  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app startup flow to verify user authentication status and route users to the appropriate screen, with enhanced error handling for authentication retrieval failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->