### PR TITLE
[HOTFIX] BoothCard 클릭 시 주점 상세 페이지 이동 기능 추가

### DIFF
--- a/src/features/main/components/BoothCard.tsx
+++ b/src/features/main/components/BoothCard.tsx
@@ -10,25 +10,29 @@ import { Image } from "react-native";
  * - 정렬된 주점 섹션에서 사용
  */
 interface BoothCardProps {
+  publicCode: string;
   name: string;
   departmentName: string;
   waitingCount: number;
   bannerImages?: string[];
   profileImage?: string;
+  onPress?: () => void;
 }
 
 export const BoothCard = ({
+  publicCode,
   name,
   departmentName,
   waitingCount,
   bannerImages,
   profileImage,
+  onPress,
 }: BoothCardProps) => {
   const waitStatusText =
     waitingCount === 0 ? "바로 입장 가능" : `대기 ${waitingCount}팀`;
 
   return (
-    <E.Container>
+    <E.Container onPress={onPress}>
       <E.BoothImage>
         {bannerImages && bannerImages[0] && (
           <E.BannerImage source={{ uri: bannerImages[0] }} resizeMode="cover" />

--- a/src/features/main/components/SortedStoresSection.tsx
+++ b/src/features/main/components/SortedStoresSection.tsx
@@ -8,6 +8,9 @@ import { SortModal } from "./SortModal";
 import { SortOption } from "@/screens/main/MainScreen";
 import { ActivityIndicator } from "react-native";
 import { useSortedStores } from "../hooks/useSortedStores";
+import { useNavigation } from "@react-navigation/native";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { RootStackParamList } from "@/app/config/routes/routes.core";
 
 /**
  * 메인 화면의 정렬된 주점 섹션 컴포넌트
@@ -30,6 +33,8 @@ export const SortedStoresSection = ({
   setSortOption,
 }: SortedStoresSectionProps) => {
   const { stores, isLoading } = useSortedStores(sortOption);
+  const navigation =
+    useNavigation<NativeStackNavigationProp<RootStackParamList>>();
 
   const sectionTitle =
     sortOption === "asc" ? "대기가 가장 적어요" : "인기가 가장 많아요";
@@ -58,6 +63,7 @@ export const SortedStoresSection = ({
           stores.map((store) => (
             <BoothCard
               key={store.storeId}
+              publicCode={store.publicCode}
               name={store.name}
               departmentName={store.departmentName}
               waitingCount={store.waitingCount}
@@ -65,6 +71,11 @@ export const SortedStoresSection = ({
                 store.bannerImageUrl ? [store.bannerImageUrl] : undefined
               }
               profileImage={undefined}
+              onPress={() =>
+                navigation.navigate("StoreDetail", {
+                  publicCode: store.publicCode,
+                })
+              }
             />
           ))
         )}


### PR DESCRIPTION
## 📄 작업 내용 요약
- BoothCard에 publicCode, onPress props 추가
- SortedStoresSection에 StoreDetail 네비게이션 연결
- 메인 화면 정렬된 주점 카드 터치 시 해당 주점 상세 페이지로 이동

## 📎 Issue #68 

<!-- closed #68  -->
